### PR TITLE
Add automated update retrieval and linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+max-line-length = 120
+extend-ignore = E203, W503
+per-file-ignores =
+    tests/*: D, E501, E402

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ ServUO Assistant is an AI companion built to support ServUO shard administrators
 
 - Script Snippet Wizardry 🧙‍♂️: The assistant conjures up ready-to-use ServUO script snippets. This magic helps both newcomers and seasoned shard admins speed up their development.
 
-- Update Oracle 📜: Always in the loop, the assistant taps into the latest happenings of the ServUO and Ultima Online worlds. Whether it's a fresh publish or a minor tweak, it's your go-to source for the most recent and relevant information.
+- Update Oracle 📜: Always in the loop, the assistant automatically pulls the latest publishes and news directly from official ServUO and Ultima Online sources. Whether it's a fresh publish or a minor tweak, it's your go-to source for the most recent and relevant information.
 
 - A Personal Touch 🎨: Decked out with custom CSS and the potential for further personalization, the assistant's UI/UX shines, offering a user experience that's both engaging and aesthetically pleasing.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,8 @@ streamlit
 streamlit-chat
 openai
 requests
-Image
+Pillow
 langchain
+feedparser
+flake8
+pytest

--- a/servuo_assistant.py
+++ b/servuo_assistant.py
@@ -3,9 +3,9 @@ import streamlit as st
 import logging
 from PIL import Image, ImageEnhance
 import time
-import json
 import base64
 from openai import OpenAI, OpenAIError
+from update_fetcher import load_game_updates
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -93,17 +93,6 @@ def load_and_enhance_image(image_path, enhance=False):
     return img
 
 
-@st.cache_data(show_spinner=False)
-def load_game_updates():
-    """Load the latest ServUO and Ultima Online updates from a local JSON file."""
-    try:
-        with open("data/servuo_updates.json", "r") as f:
-            return json.load(f)
-    except (FileNotFoundError, json.JSONDecodeError) as e:
-        logging.error(f"Error loading JSON: {str(e)}")
-        return {}
-
-
 def format_highlights(game_name, data):
     highlights = data.get("Highlights", {})
     if not highlights:
@@ -141,6 +130,13 @@ def initialize_conversation():
         {
             "role": "system",
             "content": "You were created by Madie Laine, an OpenAI Researcher.",
+        },
+        {
+            "role": "system",
+            "content": (
+                "When providing code examples, generate ServUO scripts and avoid "
+                "creating Streamlit applications."
+            ),
         },
         {"role": "assistant", "content": assistant_message},
     ]

--- a/tests/test_update_fetcher.py
+++ b/tests/test_update_fetcher.py
@@ -1,0 +1,20 @@
+"""Tests for update_fetcher module."""
+
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from update_fetcher import _fetch_servuo_updates, _fetch_ultima_online_updates
+
+
+def test_fetch_servuo_updates_structure():
+    data = _fetch_servuo_updates()
+    assert "Highlights" in data
+    assert isinstance(data["Highlights"], dict)
+
+
+def test_fetch_ultima_online_updates_structure():
+    data = _fetch_ultima_online_updates()
+    assert "Highlights" in data
+    assert isinstance(data["Highlights"], dict)

--- a/update_fetcher.py
+++ b/update_fetcher.py
@@ -1,0 +1,59 @@
+"""Utilities for retrieving ServUO and Ultima Online update data."""
+
+import logging
+from typing import Dict
+
+import feedparser
+import requests
+import streamlit as st
+
+SERVUO_RELEASES_API = "https://api.github.com/repos/ServUO/ServUO/releases/latest"
+ULTIMA_FEED_URL = "https://uo.com/feed/"
+
+
+def _fetch_servuo_updates() -> Dict[str, Dict[str, Dict[str, str]]]:
+    """Fetch latest ServUO release information from GitHub."""
+    try:
+        response = requests.get(SERVUO_RELEASES_API, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        version = data.get("name") or data.get("tag_name", "Unknown Version")
+        description = (data.get("body") or "").replace("\r\n", " ").strip()
+        url = data.get("html_url", "")
+        return {
+            "Highlights": {
+                version: {"Description": description, "Documentation": url}
+            }
+        }
+    except Exception as exc:  # pragma: no cover - network failures
+        logging.error("Error fetching ServUO updates: %s", exc)
+        return {"Highlights": {}}
+
+
+def _fetch_ultima_online_updates() -> Dict[str, Dict[str, Dict[str, str]]]:
+    """Fetch latest Ultima Online publish information from RSS feed."""
+    try:
+        feed = feedparser.parse(ULTIMA_FEED_URL)
+        for entry in feed.entries:
+            if "publish" in entry.title.lower():
+                version = entry.title
+                description = getattr(entry, "summary", "").strip()
+                url = entry.link
+                return {
+                    "Highlights": {
+                        version: {"Description": description, "Documentation": url}
+                    }
+                }
+        return {"Highlights": {}}
+    except Exception as exc:  # pragma: no cover - network failures
+        logging.error("Error fetching Ultima Online updates: %s", exc)
+        return {"Highlights": {}}
+
+
+@st.cache_data(show_spinner=False)
+def load_game_updates() -> Dict[str, Dict[str, Dict[str, Dict[str, str]]]]:
+    """Return latest updates for ServUO and Ultima Online."""
+    return {
+        "ServUO": _fetch_servuo_updates(),
+        "UltimaOnline": _fetch_ultima_online_updates(),
+    }


### PR DESCRIPTION
## Summary
- Fetch ServUO releases and Ultima Online publishes directly from official sources
- Update chat assistant to produce ServUO scripts instead of Streamlit apps
- Add flake8 config and basic tests for update retrieval

## Testing
- `python -m flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a54d48034c8329aa77b1bc3aaeabe7